### PR TITLE
Enforce tool version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,14 +1,14 @@
 - id: hlint
   name: hlint
   description: HLint is a tool for suggesting possible improvements to Haskell code.
-  entry: run.sh ndmitchell hlint hlint
+  entry: run.sh ndmitchell hlint hlint 3.4
   language: script
   files: '\.l?hs$'
   stages: [commit]
 - id: fourmolu
   name: fourmolu
   description: Fourmolu is a formatter for Haskell source code.
-  entry: run.sh MELD-labs fourmolu-binaries fourmolu --cabal-default-extensions --check-idempotence --mode inplace
+  entry: run.sh MELD-labs fourmolu-binaries fourmolu 0.6.0.0 --cabal-default-extensions --check-idempotence --mode inplace
   language: script
   files: '\.l?hs$'
   stages: [commit]


### PR DESCRIPTION
Hooks users cannot override the tools' versions in their`.pre-commit-config.yaml`, this means every time we want to upgrade the tools, we need to release a new version of this repo.

---

An attempt to resolve https://github.com/MELD-labs/github-artifacts/issues/4.